### PR TITLE
Possible Fix for Better Diving Compat

### DIFF
--- a/main/java/xzeroair/trinkets/util/compat/betterdiving/BetterDivingCompat.java
+++ b/main/java/xzeroair/trinkets/util/compat/betterdiving/BetterDivingCompat.java
@@ -1,20 +1,25 @@
 package xzeroair.trinkets.util.compat.betterdiving;
 
+import meldexun.better_diving.capability.diving.CapabilityDivingAttributesProvider;
+import meldexun.better_diving.capability.diving.ICapabilityDivingAttributes;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.fml.common.Loader;
+import xzeroair.trinkets.util.TrinketsConfig;
 
 public class BetterDivingCompat {
 
 	public static void setOxygen(EntityPlayer player, int value) {
-		//		if (TrinketsConfig.compat.betterdiving && Loader.isModLoaded("better_diving")) {
-		//			final ICapabilityDivingAttributes oxygen = player.getCapability(CapabilityDivingAttributesProvider.DIVING_ATTRIBUTES, null);
-		//			if (oxygen != null) {
-		//				if (value > 100) {
-		//					value = oxygen.getOxygenCapacityFromPlayer();
-		//				}
-		//				final int o = MathHelper.clamp(value, 0, oxygen.getOxygenCapacityFromPlayer());
-		//				oxygen.setOxygen(o);
-		//			}
-		//		}
+		if(TrinketsConfig.compat.betterdiving && Loader.isModLoaded("better_diving")) {
+			final ICapabilityDivingAttributes oxygen = player.getCapability(CapabilityDivingAttributesProvider.DIVING_ATTRIBUTES, null);
+			if(oxygen != null) {
+				if(value > 100) {
+					value = oxygen.getOxygenCapacityFromPlayer();
+				}
+				final int o = MathHelper.clamp(value, 0, oxygen.getOxygenCapacityFromPlayer());
+				oxygen.setOxygen(o);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
This code should fix the crash when equiping the Stone of the Sea into the Baubles amulet slot with the current version of Better Diving for 1.12.2 (1.5.8 at the time of writing)